### PR TITLE
Don't depend on rust-bitcoin directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 
 [dependencies]
 hex = "0.4.2"
-bitcoin = "0.23.0"
-elements = "0.12.1"
+elements = "0.13.0"
 libc = "0.2.69"
 wally-sys = { git= "https://github.com/RCasatta/wally-sys", rev="4a2f6740a18f96e7eeb73f29523757647077a069" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,9 @@
 //!
 
 use std::ptr;
+use elements::bitcoin;
+use elements::bitcoin::secp256k1;
 
-use bitcoin::secp256k1;
 use std::fmt;
 
 use bitcoin::hashes::{sha256d, Hash};


### PR DESCRIPTION
`elements` re-exports `bitcoin`. Accessing the re-export saves us
from matching the version of `bitcoin` used in `elements` in our
own dependencies.

I've also bumped the version of elements to 0.13.